### PR TITLE
[Bug fix] Batch-jberet subsystem starting up before datasource ready leads to application start failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Backport of Batch API subsystem to EAP6
  
-Tested on JBoss EAP 6.2.4 6.3 and 6.4.
+Tested on JBoss EAP 6.2.4, 6.3 and 6.4.
 
 ## Bug Fix
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 # JBeret Batch API for EAP6
 
 Backport of Batch API subsystem to EAP6
+ 
+Tested on JBoss EAP 6.2.4 6.3 and 6.4.
 
-Tested on JBoss EAP 6.2.4 and 6.3.
+## Bug Fix
 
+* Batch-jberet subsystem starting up before datasource ready leads to application start failed.
 
 ## Downloads
 
+* Refer to build section to get eap6-batch-dist-1.0.3.zip
 * [eap6-batch-dist-1.0.2.zip](http://www.e-contract.be/maven2/org/jberet/eap6/eap6-batch-dist/1.0.2/eap6-batch-dist-1.0.2.zip)
 * [eap6-batch-dist-1.0.1.zip](http://www.e-contract.be/maven2/org/jberet/eap6/eap6-batch-dist/1.0.1/eap6-batch-dist-1.0.1.zip)
 * [eap6-batch-dist-1.0.0.zip](http://www.e-contract.be/maven2/org/jberet/eap6/eap6-batch-dist/1.0.0/eap6-batch-dist-1.0.0.zip)

--- a/eap6-batch-tests/src/test/java/org/jberet/test/integration/BatchBean.java
+++ b/eap6-batch-tests/src/test/java/org/jberet/test/integration/BatchBean.java
@@ -1,16 +1,22 @@
 package org.jberet.test.integration;
 
+import org.jberet.cdi.JobScoped;
+
 import java.util.Set;
 
 import javax.annotation.PostConstruct;
 import javax.batch.operations.JobOperator;
 import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.context.JobContext;
 import javax.ejb.Stateless;
+import javax.inject.Inject;
 
 @Stateless
 public class BatchBean {
 
 	private JobOperator jobOperator;
+	@Inject
+	private JobContext jobContext;
 
 	@PostConstruct
 	public void postConstruct() {

--- a/eap6-batch/pom.xml
+++ b/eap6-batch/pom.xml
@@ -24,6 +24,10 @@
 			<artifactId>jboss-as-subsystem-test-framework</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jboss.as</groupId>
+			<artifactId>jboss-as-connector</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/eap6-batch/src/main/java/org/wildfly/extension/batch/BatchServiceNames.java
+++ b/eap6-batch/src/main/java/org/wildfly/extension/batch/BatchServiceNames.java
@@ -1,5 +1,6 @@
 package org.wildfly.extension.batch;
 
+import org.jboss.as.connector.subsystems.datasources.AbstractDataSourceService;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.threads.ThreadsServices;
 import org.jboss.msc.service.ServiceName;
@@ -21,6 +22,8 @@ public class BatchServiceNames {
      */
     public static final ServiceName BATCH_THREAD_POOL_NAME = BASE_BATCH_THREAD_POOL_NAME.append("batch");
 
+    public static final ServiceName JDBC_JOB_REPOSITORY_NAME = BASE_BATCH_THREAD_POOL_NAME.append("jdbc").append("repository");
+
     /**
      * Creates a service name for the deployment unit to define the service.
      *
@@ -41,5 +44,9 @@ public class BatchServiceNames {
      */
     public static ServiceName beanManagerServiceName(final DeploymentUnit deploymentUnit) {
         return deploymentUnit.getServiceName().append("beanmanager");
+    }
+
+    public static ServiceName dataSourceServiceName(final String jndiName) {
+        return ServiceName.JBOSS.append("data-source").append(jndiName);
     }
 }

--- a/eap6-batch/src/main/java/org/wildfly/extension/batch/job/repository/JobRepositoryFactory.java
+++ b/eap6-batch/src/main/java/org/wildfly/extension/batch/job/repository/JobRepositoryFactory.java
@@ -68,7 +68,7 @@ public class JobRepositoryFactory {
     }
 
     public boolean requiresJndiName() {
-        return JobRepositoryType.JDBC == type && jndiName == null;
+        return JobRepositoryType.JDBC == type && jndiName != null;
     }
 
     public void setJndiName(final String jndiName) {

--- a/eap6-batch/src/main/java/org/wildfly/extension/batch/job/repository/JobRepositoryService.java
+++ b/eap6-batch/src/main/java/org/wildfly/extension/batch/job/repository/JobRepositoryService.java
@@ -1,0 +1,221 @@
+package org.wildfly.extension.batch.job.repository;
+
+import org.jberet.job.model.Job;
+import org.jberet.repository.*;
+import org.jberet.runtime.*;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.JobInstance;
+import javax.batch.runtime.StepExecution;
+import javax.sql.DataSource;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A service which provides a JDBC job repository which delegates to a {@link JobRepository} throwing an {@link IllegalStateException} if the
+ * service has been stopped.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class JobRepositoryService implements JobRepository, Service<JobRepository> {
+
+    private final InjectedValue<DataSource> dataSourceValue = new InjectedValue<DataSource>();
+    private final InjectedValue<ExecutorService> executor = new InjectedValue<ExecutorService>();
+    private volatile JobRepository jobRepository;
+    private volatile boolean started;
+
+    @Override
+    public final void start(final StartContext context) throws StartException {
+        startJobRepository(context);
+        started = true;
+    }
+
+    @Override
+    public final void stop(final StopContext context) {
+        jobRepository = null;
+        started = false;
+    }
+
+    @Override
+    public final JobRepository getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    @Override
+    public void addJob(final ApplicationAndJobName applicationAndJobName, final Job job) {
+        getAndCheckDelegate().addJob(applicationAndJobName, job);
+    }
+
+    @Override
+    public void removeJob(final String jobId) {
+        getAndCheckDelegate().removeJob(jobId);
+    }
+
+    @Override
+    public Job getJob(final ApplicationAndJobName applicationAndJobName) {
+        return getAndCheckDelegate().getJob(applicationAndJobName);
+    }
+
+    @Override
+    public Set<String> getJobNames() {
+        return getAndCheckDelegate().getJobNames();
+    }
+
+    @Override
+    public boolean jobExists(final String jobName) {
+        return getAndCheckDelegate().jobExists(jobName);
+    }
+
+    @Override
+    public JobInstanceImpl createJobInstance(final Job job, final String applicationName, final ClassLoader classLoader) {
+        return getAndCheckDelegate().createJobInstance(job, applicationName, classLoader);
+    }
+
+    @Override
+    public void removeJobInstance(final long jobInstanceId) {
+        getAndCheckDelegate().removeJobInstance(jobInstanceId);
+    }
+
+    @Override
+    public JobInstance getJobInstance(final long jobInstanceId) {
+        return getAndCheckDelegate().getJobInstance(jobInstanceId);
+    }
+
+    @Override
+    public List<JobInstance> getJobInstances(final String jobName) {
+        return getAndCheckDelegate().getJobInstances(jobName);
+    }
+
+    @Override
+    public int getJobInstanceCount(final String jobName) {
+        return getAndCheckDelegate().getJobInstanceCount(jobName);
+    }
+
+    @Override
+    public JobExecutionImpl createJobExecution(final JobInstanceImpl jobInstance, final Properties jobParameters) {
+        return getAndCheckDelegate().createJobExecution(jobInstance, jobParameters);
+    }
+
+    @Override
+    public JobExecution getJobExecution(final long jobExecutionId) {
+        return getAndCheckDelegate().getJobExecution(jobExecutionId);
+    }
+
+    @Override
+    public List<JobExecution> getJobExecutions(final JobInstance jobInstance) {
+        return getAndCheckDelegate().getJobExecutions(jobInstance);
+    }
+
+    @Override
+    public void updateJobExecution(final JobExecutionImpl jobExecution, final boolean fullUpdate, final boolean saveJobParameters) {
+        getAndCheckDelegate().updateJobExecution(jobExecution, fullUpdate, saveJobParameters);
+    }
+
+    @Override
+    public List<Long> getRunningExecutions(final String jobName) {
+        return getAndCheckDelegate().getRunningExecutions(jobName);
+    }
+
+    @Override
+    public void removeJobExecutions(final JobExecutionSelector jobExecutionSelector) {
+        getAndCheckDelegate().removeJobExecutions(jobExecutionSelector);
+    }
+
+    @Override
+    public List<StepExecution> getStepExecutions(final long jobExecutionId, final ClassLoader classLoader) {
+        return getAndCheckDelegate().getStepExecutions(jobExecutionId, classLoader);
+    }
+
+    @Override
+    public StepExecutionImpl createStepExecution(final String stepName) {
+        return getAndCheckDelegate().createStepExecution(stepName);
+    }
+
+    @Override
+    public void addStepExecution(final JobExecutionImpl jobExecution, final StepExecutionImpl stepExecution) {
+        getAndCheckDelegate().addStepExecution(jobExecution, stepExecution);
+    }
+
+    @Override
+    public void updateStepExecution(final StepExecution stepExecution) {
+        getAndCheckDelegate().updateStepExecution(stepExecution);
+    }
+
+    @Override
+    public StepExecutionImpl findOriginalStepExecutionForRestart(final String stepName, final JobExecutionImpl jobExecutionToRestart, final ClassLoader classLoader) {
+        return getAndCheckDelegate().findOriginalStepExecutionForRestart(stepName, jobExecutionToRestart, classLoader);
+    }
+
+    @Override
+    public int countStepStartTimes(final String stepName, final long jobInstanceId) {
+        return getAndCheckDelegate().countStepStartTimes(stepName, jobInstanceId);
+    }
+
+    @Override
+    public void addPartitionExecution(final StepExecutionImpl enclosingStepExecution, final PartitionExecutionImpl partitionExecution) {
+        getAndCheckDelegate().addPartitionExecution(enclosingStepExecution, partitionExecution);
+    }
+
+    @Override
+    public List<PartitionExecutionImpl> getPartitionExecutions(final long stepExecutionId, final StepExecutionImpl stepExecution, final boolean notCompletedOnly, final ClassLoader classLoader) {
+        return getAndCheckDelegate().getPartitionExecutions(stepExecutionId, stepExecution, notCompletedOnly, classLoader);
+    }
+
+    @Override
+    public void savePersistentData(final JobExecution jobExecution, final AbstractStepExecution stepOrPartitionExecution) {
+        getAndCheckDelegate().savePersistentData(jobExecution, stepOrPartitionExecution);
+    }
+
+    private JobRepository getAndCheckDelegate() {
+        final JobRepository delegate = getDelegate();
+        if (started && delegate != null) {
+            return delegate;
+        }
+        throw new IllegalStateException("The service JobOperatorService has been stopped and cannot execute operations.");
+    }
+
+    public void startJobRepository(final StartContext context) throws StartException {
+
+        final ExecutorService service = executor.getValue();
+        try {
+            service.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        if (JobRepositoryFactory.getInstance().requiresJndiName()) {
+                            // Currently in jBeret tables are created in the constructor which is why this is done asynchronously
+                            jobRepository = new JdbcRepository(dataSourceValue.getValue());
+                        } else {
+                            jobRepository = InMemoryRepository.getInstance();
+                        }
+                        context.complete();
+                    } catch (Exception e) {
+                        context.failed( new StartException("Failed to create JDBC job repository."));
+                    }
+                }
+            });
+        } finally {
+            context.asynchronous();
+        }
+    }
+
+    protected JobRepository getDelegate() {
+        return jobRepository;
+    }
+    public InjectedValue<DataSource> getDataSourceInjector() {
+        return dataSourceValue;
+    }
+    public Injector<ExecutorService> getExecutorServiceInjector() {
+        return executor;
+    }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
 			</dependency>
 			<dependency>
 				<groupId>org.jboss.as</groupId>
+				<artifactId>jboss-as-connector</artifactId>
+				<version>7.2.0.Final</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jboss.as</groupId>
 				<artifactId>jboss-as-security</artifactId>
 				<version>7.2.0.Final</version>
 			</dependency>


### PR DESCRIPTION
Solution:
1. Provide a way to find datasource service instead of lookup it by jndi name.
2. Back port JobRepositoryService from WildFly 10 to provide job repository, also add datasource dependency on JobRepositoryService to avoid JobRepositoryService start up before datasource.